### PR TITLE
Replace missed PATH_MAX constant with CEC_PATH_MAX

### DIFF
--- a/src/test_func.c
+++ b/src/test_func.c
@@ -17,6 +17,8 @@
 #define PI 3.1415926535897932384626433832795029
 #endif
 
+#define CEC_PATH_MAX 2048
+
 
 void sphere_func (double *, double *, int , double *,double *, int); /* Sphere */
 void ellips_func(double *, double *, int , double *,double *, int); /* Ellipsoidal */
@@ -69,7 +71,7 @@ void test_func(double *x, double *f, int nx, int mx,int func_num)
 	if (ini_flag==0)
 	{
 		FILE *fpt;
-		char FileName[PATH_MAX];
+		char FileName[CEC_PATH_MAX];
 		free(M);
 		free(OShift);
 		free(y);


### PR DESCRIPTION
The constant PATH_MAX was missed and gcc-10 couldn't compile it with -Werror option. Anyway, PATH_MAX is defined in <linux/limits.h> thus using it makes the source code platform-dependent.